### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
-# Ref: https://github.com/antosubash/dotnet-version-and-release/blob/main/.github/workflows/dotnet.yml
-
 name: Build and Publish NuGet
 
 on:
   workflow_dispatch:
+  push:
+    - ll-build-release-automation
 
 concurrency:
   group: build-and-publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ name: Build and Publish NuGet
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
 
 concurrency:
   group: build-and-publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+# Ref: https://github.com/antosubash/dotnet-version-and-release/blob/main/.github/workflows/dotnet.yml
+
+name: Build and Publish NuGet
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: build-and-publish
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  build_and_publish_nuget:
+    name: Build and Publish NuGet
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Get all history to allow automatic versioning using MinVer
+
+      - name: Checkout shared actions
+        uses: actions/checkout@v4
+        with:
+          repository: tlabster/actions
+          path: ./.github/tlabs-actions
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Build and Publish NuGet
+        uses: ./.github/tlabs-actions/publish-nuget-to-nuget_org
+        with:
+          context: src
+          github_token: ${{ secrets.GH_ACCESS_TOKEN }}
+          nuget_api_key: ${{ secrets.NUGET_APIKEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Build and Publish NuGet
-        uses: ./.github/tlabs-actions/publish-nuget-to-nuget_org
+        uses: ./.github/tlabs-actions/publish-dotnet-package-to-nuget_org
         with:
           context: src
           github_token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,8 @@ name: Build and Publish NuGet
 on:
   workflow_dispatch:
   push:
-    - ll-build-release-automation
+    branches:
+      - ll-build-release-automation
 
 concurrency:
   group: build-and-publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,6 @@ name: Build and Publish NuGet
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - ll-build-release-automation
 
 concurrency:
   group: build-and-publish


### PR DESCRIPTION
This adds an action with which we can deploy the current `default` branch to nuget.

It does the following:
1. read or create the version from the cs-proj file
2. checks if this version is different than the latest git tag
   * if it is the same, it stops processing because that version has been build and pushed already
   * if it is not the same, it continues with next step
3. builds the package
4. uploads the package to nuget.org
5. add a new git tag with the version from 1.